### PR TITLE
Bugfix: Add missing hackathon

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ Insight can help you with your GitHub Copilot adoption journey. Find out more by
 
 ### Data Engineer
 
+- [GitHub Copilot Hackathon for Python Data Engineer](https://github.com/GitHub-Insight-ANZ-Lab/copilot-hackathon-data-engineer-python)
 - [GitHub Copilot Lab for SQL](https://github.com/GitHub-Insight-ANZ-Lab/copilot-lab-sql) (database development using Structured Query Language (SQL))
 
 ### Data Scientist
 
-- [GitHub Copilot Hackathon in Python](https://github.com/GitHub-Insight-ANZ-Lab/copilot-hackathon-data-engineer-python)
+- [GitHub Copilot Hackathon for Python Data Scientist](https://github.com/GitHub-Insight-ANZ-Lab/copilot-hackathon-data-scientist-python)
 - [GitHub Copilot Lab in R](https://github.com/GitHub-Insight-ANZ-Lab/copilot-lab-r) (statistical computing using R)
 
 ### DevOps

--- a/docs/00-Welcome.md
+++ b/docs/00-Welcome.md
@@ -28,11 +28,12 @@ Insight can help you with your GitHub Copilot adoption journey. Find out more by
 
 ### Data Engineer
 
+- [GitHub Copilot Hackathon for Python Data Engineer](https://github.com/GitHub-Insight-ANZ-Lab/copilot-hackathon-data-engineer-python)
 - [GitHub Copilot Lab for SQL](https://github.com/GitHub-Insight-ANZ-Lab/copilot-lab-sql) (database development using Structured Query Language (SQL))
 
 ### Data Scientist
 
-- [GitHub Copilot Hackathon in Python](https://github.com/GitHub-Insight-ANZ-Lab/copilot-hackathon-data-engineer-python)
+- [GitHub Copilot Hackathon for Python Data Scientist](https://github.com/GitHub-Insight-ANZ-Lab/copilot-hackathon-data-scientist-python)
 - [GitHub Copilot Lab in R](https://github.com/GitHub-Insight-ANZ-Lab/copilot-lab-r) (statistical computing using R)
 
 ### DevOps


### PR DESCRIPTION
This pull request includes updates to the links for GitHub Copilot hackathons and labs in the `README.md` and `docs/00-Welcome.md` files. The changes ensure that the links are correctly categorized and point to the appropriate resources for different roles.

Updates to links:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R43): Updated the links for the GitHub Copilot hackathons for Python Data Engineer and Python Data Scientist.
* [`docs/00-Welcome.md`](diffhunk://#diff-37281ddf090b08d53fafd186e3b510e3e8edd29686768cc9f4ce91e844d947eaR31-R36): Updated the links for the GitHub Copilot hackathons for Python Data Engineer and Python Data Scientist.