### PR TITLE
Update URL for Terraform DevOps hackathon

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Insight can help you with your GitHub Copilot adoption journey. Find out more by
 
 ### DevOps
 
-- [GitHub Copilot Hackathon DevOps](https://github.com/GitHub-Insight-ANZ-Lab/copilot-hackathon-devops) (Azure, Terraform, Docker, GitHub Actions)
+- [GitHub Copilot Hackathon for DevOps with Terraform](https://github.com/GitHub-Insight-ANZ-Lab/copilot-hackathon-devops-terraform) (Azure, Terraform, Docker, GitHub Actions)
 
 ## Visual Studio 2022+
 

--- a/docs/00-Welcome.md
+++ b/docs/00-Welcome.md
@@ -43,7 +43,7 @@ Happy coding! 💻✨
 
 ### DevOps Engineers
 
-- [GitHub Copilot Hackathon DevOps](https://github.com/GitHub-Insight-ANZ-Lab/copilot-hackathon-devops) (Azure, Terraform, Docker, GitHub Actions)
+- [GitHub Copilot Hackathon for DevOps with Terraform](https://github.com/GitHub-Insight-ANZ-Lab/copilot-hackathon-devops-terraform) (Azure, Terraform, Docker, GitHub Actions)
 
 ### Data Engineers
 


### PR DESCRIPTION
This pull request updates the URL for the Terraform DevOps hackathon in the README file. The new URL points to the GitHub repository for the hackathon with Terraform, Azure, Docker, and GitHub Actions.