### PR TITLE
add architect lab

### DIFF
--- a/docs/00-Welcome.md
+++ b/docs/00-Welcome.md
@@ -57,4 +57,8 @@ Happy coding! 💻✨
 - [GitHub Copilot Challenge for Python Data Scientist](https://github.com/GitHub-Insight-ANZ-Lab/copilot-challenge-data-scientist-python) (VS Code, Python, Jupyter Notebooks)
 - [GitHub Copilot Lab in R](https://github.com/GitHub-Insight-ANZ-Lab/copilot-lab-r) (VS Code, R for Statistical Computing)
 
+### Architect
+
+- [GitHub Copilot Lab for Architect](https://github.com/GitHub-Insight-ANZ-Lab/copilot-lab-architect-mermaid-markdown) (C#, Markdown, Mermaid)
+
 ---

--- a/docs/00-Welcome.md
+++ b/docs/00-Welcome.md
@@ -59,6 +59,6 @@ Happy coding! 💻✨
 
 ### Architect
 
-- [GitHub Copilot Lab for Architect](https://github.com/GitHub-Insight-ANZ-Lab/copilot-lab-architect-mermaid-markdown) (C#, Markdown, Mermaid)
+- [GitHub Copilot Lab for Architect](https://github.com/GitHub-Insight-ANZ-Lab/copilot-lab-architect-mermaid-markdown) (C#, Markdown, Mermaid, Enterprise Features)
 
 ---


### PR DESCRIPTION
This pull request updates the `docs/00-Welcome.md` file to include a new section titled "Architect" with relevant resources for architects.

Documentation update:

* [`docs/00-Welcome.md`](diffhunk://#diff-37281ddf090b08d53fafd186e3b510e3e8edd29686768cc9f4ce91e844d947eaR60-R63): Added a new "Architect" section with a link to the GitHub Copilot Lab for Architect, which includes resources for C#, Markdown, Mermaid, and enterprise features.